### PR TITLE
Support default and request-defined source parameter

### DIFF
--- a/bin/imageServer.py
+++ b/bin/imageServer.py
@@ -35,6 +35,7 @@ from lsst.dax.imgserv import imageREST_v0
 app = Flask(__name__)
 
 app.register_blueprint(imageREST_v0.imageREST, url_prefix='/image')
+app.config["dax.imgserv.default_source"] = "/lsst7/releaseW13EP"
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
Remove print function (already logged at info level)
Rename request to _request so it's clear that method is passed from the initial call into the Blueprint methods.
Use Sphinx REST API documentation for a few methods.
Make PEP8 checker happier.